### PR TITLE
[FIX] tile server request header (openstreetMap: response 403 if user-agent is not set

### DIFF
--- a/examples/custom-tile-source.js
+++ b/examples/custom-tile-source.js
@@ -18,6 +18,11 @@ var osm = {
   cachepath: "cache"
 }
 
-app.use("/osm", tilecache(osm));
+var tile_server_request_options = {
+  headers: {'user-agent': 'express-tile-cache'}
+}
+
+
+app.use("/osm", tilecache(osm, tile_server_request_options));
 
 app.listen(process.env.PORT || 3000);

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,9 +13,10 @@ var crypto = require('crypto');
 module.exports = TileCache;
 
 
-function TileCache(options) {
+function TileCache(options, tile_server_request_options ) {
+ tile_server_request_options = tile_server_request_options || {};
   if (!(this instanceof TileCache)) {
-    return new TileCache(options);
+    return new TileCache(options, tile_server_request_options);
   }
   this.urlRotator = 0;
 
@@ -92,7 +93,7 @@ function TileCache(options) {
           debug('Tile: %s', url);
 
           request
-            .get(url)
+            .get(url, tile_server_request_options)
             .on('error', /* istanbul ignore next */ function(er){
               debug('Server error');
               debug(er);


### PR DESCRIPTION
In case of OpenStreetMap we must add use-agent in the header request , it will be cool to let the developer setting some customs headers ;)